### PR TITLE
Add basic ping pong game page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import Documentation from "./pages/Documentation";
+import PingPong from "./pages/PingPong";
 
 const queryClient = new QueryClient();
 
@@ -17,6 +18,7 @@ const App = () => (
         <Routes>
           <Route path="/" element={<Index />} />
           <Route path="/docs" element={<Documentation />} />
+          <Route path="/ping-pong" element={<PingPong />} />
         </Routes>
       </BrowserRouter>
     </TooltipProvider>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Copy } from "lucide-react";
+import { Link } from "react-router-dom";
 import { HeroSection } from "@/components/home/HeroSection";
 import { ComparisonSection } from "@/components/home/ComparisonSection";
 import { FeatureSection } from "@/components/home/FeatureSection";
@@ -33,6 +34,12 @@ const Index = () => {
       <FeatureSection />
       <MevSection />
       <ComparisonSection />
+
+      <div className="fixed bottom-4 right-4">
+        <Link to="/ping-pong">
+          <Button variant="secondary">Play Ping Pong</Button>
+        </Link>
+      </div>
 
       <Dialog open={showDepositDialog} onOpenChange={setShowDepositDialog}>
         <DialogContent className="glass-dialog sm:max-w-md dialog-content">

--- a/src/pages/PingPong.tsx
+++ b/src/pages/PingPong.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useRef } from "react";
+
+const PingPong = () => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const width = canvas.width;
+    const height = canvas.height;
+    const paddleWidth = 10;
+    const paddleHeight = 75;
+    const ballRadius = 8;
+
+    let leftY = height / 2 - paddleHeight / 2;
+    let rightY = leftY;
+    let ballX = width / 2;
+    let ballY = height / 2;
+    let ballVX = 4;
+    let ballVY = 4;
+    const keys: Record<string, boolean> = {};
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      keys[e.key] = true;
+    };
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      keys[e.key] = false;
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    document.addEventListener("keyup", handleKeyUp);
+
+    const resetBall = () => {
+      ballX = width / 2;
+      ballY = height / 2;
+      ballVX = -ballVX;
+      ballVY = 4 * (Math.random() > 0.5 ? 1 : -1);
+    };
+
+    let animationId: number;
+    const loop = () => {
+      if (keys.w) {
+        leftY = Math.max(leftY - 5, 0);
+      }
+      if (keys.s) {
+        leftY = Math.min(leftY + 5, height - paddleHeight);
+      }
+      if (keys.ArrowUp) {
+        rightY = Math.max(rightY - 5, 0);
+      }
+      if (keys.ArrowDown) {
+        rightY = Math.min(rightY + 5, height - paddleHeight);
+      }
+
+      ballX += ballVX;
+      ballY += ballVY;
+
+      if (ballY - ballRadius <= 0 || ballY + ballRadius >= height) {
+        ballVY *= -1;
+      }
+
+      if (ballX - ballRadius <= paddleWidth) {
+        if (ballY >= leftY && ballY <= leftY + paddleHeight) {
+          ballVX *= -1;
+        } else {
+          resetBall();
+        }
+      }
+
+      if (ballX + ballRadius >= width - paddleWidth) {
+        if (ballY >= rightY && ballY <= rightY + paddleHeight) {
+          ballVX *= -1;
+        } else {
+          resetBall();
+        }
+      }
+
+      ctx.fillStyle = "black";
+      ctx.fillRect(0, 0, width, height);
+
+      ctx.fillStyle = "white";
+      ctx.fillRect(0, leftY, paddleWidth, paddleHeight);
+      ctx.fillRect(width - paddleWidth, rightY, paddleWidth, paddleHeight);
+
+      ctx.beginPath();
+      ctx.arc(ballX, ballY, ballRadius, 0, Math.PI * 2);
+      ctx.fill();
+
+      animationId = requestAnimationFrame(loop);
+    };
+
+    loop();
+
+    return () => {
+      cancelAnimationFrame(animationId);
+      document.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("keyup", handleKeyUp);
+    };
+  }, []);
+
+  return (
+    <div className="flex h-screen items-center justify-center bg-black">
+      <canvas
+        ref={canvasRef}
+        width={600}
+        height={400}
+        className="border border-white"
+      />
+    </div>
+  );
+};
+
+export default PingPong;


### PR DESCRIPTION
## Summary
- add a canvas-based ping pong game with keyboard controls
- expose the game at `/ping-pong` and link from home page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 3 errors in existing files)*
- `npx eslint src/pages/PingPong.tsx src/App.tsx src/pages/Index.tsx && echo 'lint passed'`


------
https://chatgpt.com/codex/tasks/task_e_68a063963f2883288c76f5e4cfe2d694